### PR TITLE
Async trace upload

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -64,7 +64,7 @@ func NewRecorder(ctx context.Context, opts ...Option) (*Recorder, error) {
 		traces := bundle.([]*pb.Trace)
 		err := rec.upload(traces)
 		if err != nil {
-			log.Printf("failed to upload %d traces to the Cloud Trace server.", len(traces))
+			log.Printf("failed to upload %d traces to the Cloud Trace server. (err = %s)", len(traces), err)
 		}
 	})
 	bundler.DelayThreshold = 2 * time.Second

--- a/recorder.go
+++ b/recorder.go
@@ -133,7 +133,7 @@ var labelMap = map[string]string{
 // rewrite well-known opentracing.ext labels into those gcloud-native labels
 func transposeLabels(labels map[string]string) {
 	for k, t := range labelMap {
-		if vv, ok := labelMap[k]; ok {
+		if vv, ok := labels[k]; ok {
 			labels[t] = vv
 			delete(labels, k)
 		}


### PR DESCRIPTION
This utilizes `google.golang.org/api/support/bundler` to asynchronously upload traces to gcloud trace rather then uploading them immediately. When using the opentracing API, span.Finish() is typically still operating in the request's goroutine and may block the response inducing unnecessary overhead. This change will also batch up to 100 traces together to upload at a time reducing your total number of API calls.

Additionally I made some cosmetic changes to the traces themselves:
* translate opentracing tags into gcloud tracing label namnes 
* copy event logs from the opentracing Span gcloud tracing into labels
  * *note:* opentracing spans can contain key value event logs. I create a label with the name event_%d where %d is the sequential log event number. Internally this does cause some allocations which may not be desirable in tight loops but since span logs typically occur in exceptional events this seems like an OK tradeoff. 