### PR TITLE
Add the ability to separate client/server spans

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -91,6 +91,7 @@ func (r *Recorder) RecordSpan(sp basictracer.RawSpan) {
 	labels := convertTags(sp.Tags)
 	transposeLabels(labels)
 	addLogs(labels, sp.Logs)
+	sp.Operation = sp.Operation + getSpanKind(sp.Tags)
 
 	trace := &pb.Trace{
 		ProjectId: r.project,
@@ -150,6 +151,17 @@ func convertTags(tags opentracing.Tags) map[string]string {
 		}
 	}
 	return labels
+}
+
+func getSpanKind(tags opentracing.Tags) string {
+	switch tags[string(ext.SpanKind)] {
+	case ext.SpanKindRPCServerEnum:
+		return "rpc_server"
+	case ext.SpanKindRPCClientEnum:
+		return "rpc_client"
+	default:
+		return ""
+	}
 }
 
 func convertSpanKind(tags opentracing.Tags) pb.TraceSpan_SpanKind {

--- a/recorder.go
+++ b/recorder.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -144,10 +143,14 @@ func convertTags(tags opentracing.Tags) map[string]string {
 	labels := make(map[string]string)
 	for k, v := range tags {
 		switch v := v.(type) {
-		case int:
-			labels[k] = strconv.Itoa(v)
 		case string:
 			labels[k] = v
+		case bool, int, int32, int64, float32, float64, uint32, uint64:
+			labels[k] = fmt.Sprintf("%v", v)
+		default:
+			if str, ok := v.(fmt.Stringer); ok {
+				labels[k] = str.String()
+			}
 		}
 	}
 	return labels

--- a/recorder.go
+++ b/recorder.go
@@ -156,9 +156,9 @@ func convertTags(tags opentracing.Tags) map[string]string {
 func getSpanKind(tags opentracing.Tags) string {
 	switch tags[string(ext.SpanKind)] {
 	case ext.SpanKindRPCServerEnum:
-		return "rpc_server"
+		return "-rpc_server"
 	case ext.SpanKindRPCClientEnum:
-		return "rpc_client"
+		return "-rpc_client"
 	default:
 		return ""
 	}
@@ -167,9 +167,9 @@ func getSpanKind(tags opentracing.Tags) string {
 func convertSpanKind(tags opentracing.Tags) pb.TraceSpan_SpanKind {
 	switch tags[string(ext.SpanKind)] {
 	case ext.SpanKindRPCServerEnum:
-		return "-" + pb.TraceSpan_RPC_SERVER
+		return pb.TraceSpan_RPC_SERVER
 	case ext.SpanKindRPCClientEnum:
-		return "-" + pb.TraceSpan_RPC_CLIENT
+		return pb.TraceSpan_RPC_CLIENT
 	default:
 		return pb.TraceSpan_SPAN_KIND_UNSPECIFIED
 	}

--- a/recorder.go
+++ b/recorder.go
@@ -167,9 +167,9 @@ func getSpanKind(tags opentracing.Tags) string {
 func convertSpanKind(tags opentracing.Tags) pb.TraceSpan_SpanKind {
 	switch tags[string(ext.SpanKind)] {
 	case ext.SpanKindRPCServerEnum:
-		return pb.TraceSpan_RPC_SERVER
+		return "-" + pb.TraceSpan_RPC_SERVER
 	case ext.SpanKindRPCClientEnum:
-		return pb.TraceSpan_RPC_CLIENT
+		return "-" + pb.TraceSpan_RPC_CLIENT
 	default:
 		return pb.TraceSpan_SPAN_KIND_UNSPECIFIED
 	}

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -19,6 +19,12 @@ func TestTraceClientImplementation(t *testing.T) {
 	_ = client
 }
 
+type stringer struct{}
+
+func (s stringer) String() string {
+	return "string!"
+}
+
 func TestRecorderClosing(t *testing.T) {
 	patchTracesCalled := false
 	closeCalled := false
@@ -46,8 +52,11 @@ func TestRecorderClosing(t *testing.T) {
 									},
 									ParentSpanId: 9,
 									Labels: map[string]string{
-										"foo": "10",
-										"bar": "foo",
+										"foo":      "10",
+										"bar":      "foo",
+										"bool":     "true",
+										"float":    "4.2",
+										"stringer": "string!",
 									},
 								},
 							},
@@ -79,8 +88,11 @@ func TestRecorderClosing(t *testing.T) {
 		Start:        time.Unix(1480425868, 0),
 		Duration:     5 * time.Second,
 		Tags: map[string]interface{}{
-			"foo": 10,
-			"bar": "foo",
+			"foo":      10,
+			"bar":      "foo",
+			"bool":     true,
+			"float":    4.2,
+			"stringer": &stringer{},
 		},
 	})
 


### PR DESCRIPTION
When a child span of a client span is a server span, Google Cloud Trace UI will not show the spans as two spans but one. See this [bug](https://issuetracker.google.com/issues/35908274) from Google 